### PR TITLE
Make "etc" directory path more generic in docs

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -39,7 +39,7 @@ curl -XDELETE 'http://localhost:9200/_template/elasticbeat'
 
 ## Import template
 ```bash
-cd ~/workspace/go/src/github.com/radoondas/elasticbeat/etc
+cd $GOPATH/src/github.com/radoondas/elasticbeat/etc
 curl -XPUT 'http://localhost:9200/_template/elasticbeat' -d@elasticbeat.template.json
 ```
 


### PR DESCRIPTION
Hi radoondas,

This is something pretty minor. I was just following the instructions and noticed this. It should use `$GOPATH`variable instead of hard coded folder path. 

What do you think?

Thanks